### PR TITLE
Fix: 불필요한 response 요소 삭제

### DIFF
--- a/controllers/debateController.js
+++ b/controllers/debateController.js
@@ -13,7 +13,7 @@ exports.debatePostMid = async (req, res) => {
         subject: req.body.subject,
       });
       const result = await Debate.createDebate(newDebate);
-      res.status(200).send({result, message: "토론이 생성되었습니다."});
+      res.status(200).send(result);
     }
   } catch (err) {
     console.error(err);
@@ -33,7 +33,7 @@ exports.historyPostMid = async (req, res) => {
         content: req.body.content,
       });
       const result = await History.createHistory(newHistory);
-      res.status(200).send({result, message: "토론 메시지가 생성되었습니다."});
+      res.status(200).send(result);
     }
   } catch (err) {
     console.error(err);

--- a/controllers/questionController.js
+++ b/controllers/questionController.js
@@ -26,7 +26,7 @@ exports.questionPostMid = async (req, res) => {
         content: req.body.content,
       });
       const result = await Question.createQuestion(newQuestion);
-      res.status(200).send({result, message: "질문을 등록했습니다."});
+      res.status(200).send(result);
     }
   } catch (err) {
     console.error(err);

--- a/controllers/reportController.js
+++ b/controllers/reportController.js
@@ -11,9 +11,9 @@ exports.reportPostMid = async (req, res) => {
       comment: req.body.comment,
     });
     const result = await Report.createReport(newReport);
-    res.status(200).send({result, success: true, message: "신고했습니다."});
+    res.status(200).send(result);
   } catch (err) {
     console.error(err);
-    res.status(404).send({success: false, message: "오류가 발생했습니다."});
+    res.status(404).send({message: "오류가 발생했습니다."});
   }
 };


### PR DESCRIPTION
- 질문/토론/신고 Controller의 response에서 필요없는 요소를 삭제했습니다.
- response로 결과값이 있을 경우 결과값만 보내도록 하였고, response로 결과값이 없을 경우 message로 성공 여부를 확인할 수 있게 하였습니다.
- success 여부는 오히려 불필요하다고 느꼈고... 한다면 다른 컨트롤러들과도 통일하는 게 좋을 것 같아 일단은 제외했습니다. 이후 추가가 필요할 경우 다른 브랜치 파서 작업할 예정입니다.