### PR TITLE
Fix: 질문 검색 api 닉네임 추가

### DIFF
--- a/models/questionModel.js
+++ b/models/questionModel.js
@@ -123,7 +123,11 @@ Question.likeQuestion = async (id, user_id) => {
 };
 
 Question.getQuestionSearchByQuery = async (query) => {
-  const result = await pool.query(`SELECT * FROM questions WHERE content LIKE ?`, [`%${query}%`]);
+  const result = await pool.query(
+    `SELECT questions.*, users.nickname  
+    FROM questions INNER JOIN users ON questions.user_id = users.id
+    WHERE content LIKE ?`, [`%${query}%`]
+  );
   return result[0];
 };
 

--- a/swagger/swagger_output.json
+++ b/swagger/swagger_output.json
@@ -2848,7 +2848,8 @@
                           "content": "고양이는 얼마나 귀여운가요?",
                           "created_at": "2023-07-18T12:32:18.000Z",
                           "answer_or_not": 0,
-                          "is_bad": 0
+                          "is_bad": 0,
+                          "nickname": "고양이좋아"
                         },
                         {
                           "id": 2,
@@ -2858,7 +2859,8 @@
                           "content": "고양이는 얼마나 귀여운가요?",
                           "created_at": "2023-07-18T12:35:35.000Z",
                           "answer_or_not": 0,
-                          "is_bad": 1
+                          "is_bad": 1,
+                          "nickname": "test"
                         }
                       ]
                     }


### PR DESCRIPTION
프론트 측 요청사항 반영하여 수정했습니다.
- `GET /question/query/{query(*)}` 유저 닉네임 추가

https://www.notion.so/034179/question-query-query-4c78c34dd7e442b6ae6ede2cbc9d21ed