### PR TITLE
fix: 토론 생성 불가 버그 수정

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -372,7 +372,7 @@ CREATE TABLE
         `id` int NOT NULL AUTO_INCREMENT,
         `doc_id` int NOT NULL,
         `user_id` int NOT NULL,
-        `subject` varchar(20) NOT NULL,
+        `subject` varchar(255) NOT NULL,
         `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
         `recent_edited_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
         -- 가장 마지막으로 토론한 시각


### PR DESCRIPTION
토론 생성이 안되는 버그 확인 결과, debates 테이블의 subject 컬럼 길이 제한 문제가 있어 varchar 글자수를 여유 있게 변경하였습니다.

DB상에는 이미 반영하였으며, 본 PR에서는 `schema.sql`이 변경되었습니다. 그 외 변경사항 없습니다.